### PR TITLE
Cache listing requests for namespace/categories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ setuptools>=18.0
 setuptools-scm>=1.5.4
 setuptools-scm-git-archive,
 tiledb>=0.6.6,
-tiledb-cloud>=0.6.4
+tiledb-cloud>=0.6.5

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     "setuptools-scm>=1.5.4",
     "setuptools-scm-git-archive",
     "tiledb>=0.6.6",
-    "tiledb-cloud>=0.6.4",
+    "tiledb-cloud>=0.6.5",
 ]
 
 setup(


### PR DESCRIPTION
During notebook startup we are observing up to 3 requests being made for listing categories/namespaces within rapid succession. This causes delays in starting the environment so we'll cache a notebook listing if it is within the last 4 seconds.