### PR TITLE
Switch notebooks from tags to file properties

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ setuptools>=18.0
 setuptools-scm>=1.5.4
 setuptools-scm-git-archive,
 tiledb>=0.6.6,
-tiledb-cloud>=0.6.5
+tiledb-cloud>=0.6.6

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     "setuptools-scm>=1.5.4",
     "setuptools-scm-git-archive",
     "tiledb>=0.6.6",
-    "tiledb-cloud>=0.6.5",
+    "tiledb-cloud>=0.6.6",
 ]
 
 setup(


### PR DESCRIPTION
TileDB Cloud Arrays now have file type and file properties which allow for better and more robust handling of special types like the notebook files.