### PR TITLE
Jupyterlab itself has a dependency on nose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 notebook
+nose
 ipykernel
 setuptools>=18.0
 setuptools-scm>=1.5.4

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ NAME = "tiledbcontents"
 
 REQUIRES = [
     "notebook",
+    "nose",
     "ipykernel",
     "setuptools>=18.0",
     "setuptools-scm>=1.5.4",


### PR DESCRIPTION
This dependency is missing upstream so on fresh clean installations sometimes the plugin fails to install with nose missing. We add it here to improve the user installation experience.