### PR TITLE
Close array to clear resources

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -83,6 +83,9 @@ class Array:
         :return:
         """
         try:
+            if self.array is not None:
+                self.array.close()
+
             self.array = tiledb.open(self.uri, ctx=TILEDB_CONTEXT)
         except Exception as e:
             raise http_error(


### PR DESCRIPTION
The python GC will take care of this, but if we close right away resources are freed faster. This is just an optimization.