### PR TITLE
Store notebooks as a dense array

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ ipykernel
 setuptools>=18.0
 setuptools-scm>=1.5.4
 setuptools-scm-git-archive,
-tiledb>=0.6.6,
+tiledb>=0.7.0,
 tiledb-cloud>=0.6.7

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     "setuptools>=18.0",
     "setuptools-scm>=1.5.4",
     "setuptools-scm-git-archive",
-    "tiledb>=0.6.6",
+    "tiledb>=0.7.0",
     "tiledb-cloud>=0.6.7",
 ]
 

--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -357,7 +357,7 @@ class TileDBContents(ContentsManager):
 
             schema = tiledb.ArraySchema(
                 domain=dom,
-                sparse=True,
+                sparse=False,
                 attrs=[
                     tiledb.Attr(
                         name="contents",
@@ -387,7 +387,7 @@ class TileDBContents(ContentsManager):
             )
 
             # Create the (empty) array on disk.
-            tiledb.SparseArray.create(tiledb_uri_s3, schema)
+            tiledb.DenseArray.create(tiledb_uri_s3, schema)
 
             tiledb_uri = "tiledb://{}/{}".format(namespace, array_name)
             time.sleep(0.25)


### PR DESCRIPTION
Store notebooks as a dense array now that TileDB-Py 0.7 with TileDB 2.1 is out.