### PR TITLE
Replaces invalid utf-8 chars with backslash when decoding file contents

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -710,7 +710,7 @@ class TileDBContents(ContentsManager):
                 file_content = arr.read()
                 if file_content is not None:
                     nb_content = reads(
-                        file_content["contents"].tostring().decode("utf-8"),
+                        file_content["contents"].tostring().decode("utf-8", "backslashreplace"),
                         as_version=NBFORMAT_VERSION,
                     )
                     self.mark_trusted_cells(nb_content, uri)
@@ -778,7 +778,7 @@ class TileDBContents(ContentsManager):
                     and file_content is not None
                 ):
                     nb_content = reads(
-                        file_content["contents"].tostring().decode("utf-8"),
+                        file_content["contents"].tostring().decode("utf-8", "backslashreplace"),
                         as_version=NBFORMAT_VERSION,
                     )
                     self.mark_trusted_cells(nb_content, uri)


### PR DESCRIPTION
Error opening notebook cloud/shared/seth/Rady-HPO-Example: HTTP 400: Bad Request (Error fetching notebook: ‘utf-8’ codec can’t decode byte 0xd7 in position 8556: invalid continuation byte)

Available choices for second argument
(https://docs.python.org/3/howto/unicode.html)

```
>>> b'\x80abc'.decode("utf-8", "strict")  
Traceback (most recent call last):
    ...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0:
  invalid start byte
>>> b'\x80abc'.decode("utf-8", "replace")
'\ufffdabc'
>>> b'\x80abc'.decode("utf-8", "backslashreplace")
'\\x80abc'
>>> b'\x80abc'.decode("utf-8", "ignore")
'abc'
```