### PR TITLE
Clean up some lints in tiledbcontents.

### DIFF
--- a/tiledbcontents/ipycompat.py
+++ b/tiledbcontents/ipycompat.py
@@ -5,41 +5,31 @@ Taken from: https://github.com/danielfrg/s3contents/blob/master/s3contents/ipyco
 Which original took it from: https://github.com/quantopian/pgcontents/blob/master/pgcontents/utils/ipycompat.py
 """
 
-import notebook
-
-# if notebook.version_info[0] >= 7:  # noqa
-#     raise ImportError("Jupyter Notebook versions 6 and up are not supported.")
-
-from traitlets.config import Config
-from notebook.services.contents.checkpoints import (
-    Checkpoints,
-    GenericCheckpointsMixin,
-)
-from notebook.services.contents.filemanager import FileContentsManager
+from nbformat import from_dict
+from nbformat import reads
+from nbformat import writes
+from nbformat.v4.nbbase import new_code_cell
+from nbformat.v4.nbbase import new_markdown_cell
+from nbformat.v4.nbbase import new_notebook
+from nbformat.v4.nbbase import new_raw_cell
+from nbformat.v4.rwbase import strip_transient
+from notebook.services.contents.checkpoints import Checkpoints
+from notebook.services.contents.checkpoints import GenericCheckpointsMixin
 from notebook.services.contents.filecheckpoints import GenericFileCheckpoints
+from notebook.services.contents.filemanager import FileContentsManager
 from notebook.services.contents.manager import ContentsManager
-from notebook.services.contents.tests.test_manager import TestContentsManager
 from notebook.services.contents.tests.test_contents_api import APITest
+from notebook.services.contents.tests.test_manager import TestContentsManager
 from notebook.tests.launchnotebook import assert_http_error
 from notebook.utils import to_os_path
-from nbformat import from_dict, reads, writes
-from nbformat.v4.nbbase import (
-    new_code_cell,
-    new_markdown_cell,
-    new_notebook,
-    new_raw_cell,
-)
-from nbformat.v4.rwbase import strip_transient
-from traitlets import (
-    Any,
-    Bool,
-    Dict,
-    Instance,
-    Integer,
-    HasTraits,
-    Unicode,
-)
-
+from traitlets import Any
+from traitlets import Bool
+from traitlets import Dict
+from traitlets import HasTraits
+from traitlets import Instance
+from traitlets import Integer
+from traitlets import Unicode
+from traitlets.config import Config
 
 __all__ = [
     "APITest",

--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -1,26 +1,26 @@
-import os
-import json
 import datetime
+import json
+import os
+import random
+import string
 import time
-import tiledb
-import tiledb.cloud
+
 import numpy
 import pytz
-import string
-import random
-import sys
-import traceback
-
-utc = pytz.UTC
-
+import tiledb
+import tiledb.cloud
 from notebook.services.contents.checkpoints import Checkpoints
 from notebook.services.contents.filemanager import FileContentsManager
-
 from tornado.web import HTTPError
 
 from .ipycompat import ContentsManager
-from .ipycompat import HasTraits, Unicode
-from .ipycompat import reads, from_dict, GenericFileCheckpoints
+from .ipycompat import GenericFileCheckpoints
+from .ipycompat import HasTraits
+from .ipycompat import Unicode
+from .ipycompat import from_dict
+from .ipycompat import reads
+
+utc = pytz.UTC
 
 DUMMY_CREATED_DATE = datetime.datetime.fromtimestamp(86400)
 NBFORMAT_VERSION = 4
@@ -512,7 +512,7 @@ class TileDBContents(ContentsManager):
                     ),
                 )
 
-            if s3_prefix == None:
+            if s3_prefix is None:
                 s3_prefix = get_s3_prefix(namespace)
                 if s3_prefix is None:
                     raise HTTPError(
@@ -662,7 +662,7 @@ class TileDBContents(ContentsManager):
         :param uri: array URI to write
         :return:
         """
-        if model["type"] is not "notebook":
+        if model["type"] != "notebook":
             raise HTTPError(
                 403, "Only notebooks are allowed to create in cloud folders"
             )
@@ -855,9 +855,8 @@ class TileDBContents(ContentsManager):
                 try:
                     tiledb_uri = self.tiledb_uri_from_path(path_fixed)
                     return self._get_type(tiledb_uri)
-                except Exception as e:
+                except Exception:
                     return "directory"
-            return "file"
 
         if path.endswith(".ipynb"):
             return "notebook"
@@ -1522,7 +1521,7 @@ class TileDBCloudContentsManager(TileDBContents, FileContentsManager, HasTraits)
                 )
             except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
                 raise HTTPError(
-                    500, "Error deregistering {}: ".format(tiledb_uri, str(e))
+                    500, f"Error deregistering {tiledb_uri!r}: {e}"
                 )
             except tiledb.TileDBError as e:
                 raise HTTPError(
@@ -1552,7 +1551,7 @@ class TileDBCloudContentsManager(TileDBContents, FileContentsManager, HasTraits)
                     uri=tiledb_uri, notebook_name=array_name_new
                 )
             except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
-                raise HTTPError(500, "Error renaming {}: ".format(tiledb_uri, str(e)))
+                raise HTTPError(500, f"Error renaming {tiledb_uri!r}: {e}")
             except tiledb.TileDBError as e:
                 raise HTTPError(
                     500,


### PR DESCRIPTION
- Sort imports
- Replace `some_str is "something"` with `some_str == "something"`
- Remove unreachable code and unused vars
- Fix up format strings

I don’t *think* this will make it possible to upload a notebook into a cloud folder, but it is some stuff that should probably happen.