### PR TITLE
Start to modularize tiledbcontents.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ cloudpickle==1.4.1
 decorator==4.4.2
 defusedxml==0.7.1
 entrypoints==0.3
+importlib-metadata==4.5.0
 ipykernel==5.5.5
 ipython==7.24.1
 ipython-genutils==0.2.0
@@ -53,14 +54,16 @@ Send2Trash==1.5.0
 setuptools-scm==6.0.1
 setuptools-scm-git-archive==1.1
 six==1.16.0
-terminado==0.10.0
+terminado==0.10.1
 testpath==0.5.0
-tiledb==0.8.11
+tiledb==0.9.0
 tiledb-cloud==0.7.11
 tiledb-plot-widget==0.1.9
 tornado==6.1
 traitlets==5.0.5
+typing-extensions==3.10.0.0
 urllib3==1.26.5
 wcwidth==0.2.5
 webencodings==0.5.1
 widgetsnbextension==3.5.1
+zipp==3.4.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ REQUIRES = [
     "nbformat",
     "notebook",
     "numpy",
-    "pytz",
     "setuptools-scm-git-archive",
     "setuptools-scm>=1.5.4",
     "setuptools>=45",

--- a/tiledbcontents/caching.py
+++ b/tiledbcontents/caching.py
@@ -1,0 +1,171 @@
+"""Tools to handle caching of TileDB arrays and listings."""
+
+import time
+from typing import Any, Dict, Optional, Tuple, Type
+
+import tiledb
+import tiledb.cloud
+import tiledb.cloud.client
+import tornado.web
+
+CLOUD_CONTEXT = tiledb.cloud.Ctx()
+
+
+class Array:
+    """Caching wrapper around a TileDB Array."""
+
+    def __init__(self, uri: str, contents: Optional[Dict[str, Any]] = None):
+        """
+        Create an Array wrapping a TileDB Array class
+        :param uri:
+        """
+        self.uri = uri
+        try:
+            self.array: tiledb.Array = tiledb.open(uri, ctx=CLOUD_CONTEXT)
+        except Exception as e:
+            raise tornado.web.HTTPError(400, f"Error in Array init: {e}") from e
+        self.contents_fetched = False
+        self.cached_meta: Dict[str, Any] = {}
+        self.cache_metadata()
+        # Cache contents if exist during first array write
+        self.cached_contents: Optional[Dict[str, Any]] = contents
+
+    # A global cache of Arrays by URI.
+    _cache: Dict[str, "Array"] = {}
+
+    @classmethod
+    def from_cache(cls: Type["Array"], uri: str, *args, **kwargs) -> "Array":
+        """Fetches an Array from the cache, or constructs a new one if not present."""
+        try:
+            return cls._cache[uri]
+        except KeyError:
+            pass
+        cls._cache[uri] = cls(uri, *args, **kwargs)
+        return cls._cache[uri]
+
+    @classmethod
+    def purge(cls: Type["Array"], uri: str) -> None:
+        cls._cache.pop(uri, None)
+
+    def read(self) -> Optional[Dict[str, Any]]:
+        """
+        Fetch all contents of the array based on file_size metadata field
+        :return: raw bytes of content
+        """
+
+        try:
+            if self.cached_contents is not None:
+                contents = self.cached_contents
+                # Invalidate cached contents after first read
+                # Used only to speed up first read after creation, avoiding the server roundtrip
+                # since contents are already available
+                self.cached_contents = None
+                return contents
+
+            if self.contents_fetched:
+                self.reopen()
+
+            self.contents_fetched = True
+            meta = self.array.meta
+            if "file_size" in meta:
+                return self.array[slice(0, meta["file_size"])]
+        except Exception as e:
+            raise tornado.web.HTTPError(400, f"Error in Array::read: {e}") from e
+
+        return None
+
+    def reopen(self):
+        """
+        Reopen an array at the current timestamp
+        :return:
+        """
+        try:
+            if self.array is not None:
+                self.array.close()
+
+            self.array = tiledb.open(self.uri, ctx=CLOUD_CONTEXT)
+        except Exception as e:
+            raise tornado.web.HTTPError(400, f"Error in Array::reopen: {e}") from e
+
+    def cache_metadata(self):
+        try:
+            self.cached_meta = dict(self.array.meta.items())
+        except Exception as e:
+            raise tornado.web.HTTPError(
+                400, f"Error in Array::cache_metadata: {e}"
+            ) from e
+
+
+_CATEGORY_LOADERS = {
+    "owned": tiledb.cloud.client.list_arrays,
+    "shared": tiledb.cloud.client.list_shared_arrays,
+    "public": tiledb.cloud.client.list_public_arrays,
+}
+
+_CACHE_SECS = 4
+
+
+class ArrayListing:
+    """An ArrayListing which will cache results for a specified time."""
+
+    def __init__(self, category: str, namespace: Optional[str] = None):
+        """
+        Create an ArrayListing which will cache results for specified time
+        :param category: category to list
+        :param namespace: namespace to filter to
+        :param cache_secs: cache time, defaults to 4 seconds
+        """
+        self.category = category
+        self.namespace = namespace
+        self.array_listing_future = None
+        self.last_fetched: Optional[float] = None
+
+    # A global cache of ArrayListings by category.
+    _cache: Dict[Tuple[str, Optional[str]], "ArrayListing"] = {}
+
+    @classmethod
+    def from_cache(
+        cls: Type["ArrayListing"], category: str, namespace: Optional[str] = None,
+    ) -> "ArrayListing":
+        """Fetches an ArrayListing from the cache, or constructs a new one if not present."""
+        try:
+            return cls._cache[category, namespace]
+        except KeyError:
+            pass
+        cls._cache[category, namespace] = cls(category, namespace)
+        return cls._cache[category, namespace]
+
+    def _should_fetch(self):
+        return (
+            self.last_fetched is None
+            or self.array_listing_future is None
+            or self.last_fetched + _CACHE_SECS < time.time()
+        )
+
+    def fetch(self):
+        if self._should_fetch():
+            try:
+                loader = _CATEGORY_LOADERS[self.category]
+            except KeyError:
+                raise ValueError(
+                    f"Invalid category name {self.category!r}; "
+                    f"must be one of {set(_CATEGORY_LOADERS.keys())}"
+                ) from None
+            self.array_listing_future = loader(
+                file_type=[tiledb.cloud.rest_api.models.FileType.NOTEBOOK],
+                namespace=self.namespace,
+                async_req=True,
+            )
+            self.last_fetched = time.time()
+
+        return self
+
+    def get(self):
+        if self.array_listing_future is None:
+            self.fetch()
+
+        return self.array_listing_future.get()
+
+    def arrays(self):
+        ret = self.get()
+        return ret and ret.arrays

--- a/tiledbcontents/paths.py
+++ b/tiledbcontents/paths.py
@@ -1,0 +1,138 @@
+"""Tools for dealing with paths (and ancillary things like credentials)."""
+
+
+import random
+import string
+from typing import Optional
+
+
+NOTEBOOK_EXT = ".ipynb"
+_NB_NO_DOT = NOTEBOOK_EXT[1:]
+
+
+def tiledb_uri_from_path(path: str) -> str:
+    """Builds a tiledb:// URI from a notebook cloud path.
+
+    >>> tiledb_uri_from_path("cloud/owned/namespace/nbname")
+    'tiledb://namespace/nbname'
+    """
+
+    parts = path.split("/")
+    return f"tiledb://{parts[-2]}/{parts[-1]}"
+
+
+_ID_CHARS = string.ascii_uppercase + string.digits
+
+
+def generate_id(size: int = 6, chars: str = _ID_CHARS) -> str:
+    """Generates a random-ish ID."""
+    return "".join(random.choice(chars) for _ in range(size))
+
+
+def increment_filename(filename: str, insert: str = "-") -> str:
+    """Increments the number in a filename in the hopes of making it unique.
+
+    >>> increment_filename("path-to-my.tar.gz")
+    'path-to-my-1.tar.gz'
+    >>> increment_filename("mr. number 9.ipynb", " ")
+    'mr. number 10.ipynb'
+    >>> increment_filename("no-extension-6")
+    'no-extension-7'
+    """
+    basename, dot, ext = filename.rpartition(".")
+    if ext != _NB_NO_DOT:
+        # for non-ipynb files, assume that the first dot starts the suffix
+        # (e.g. "something.tar.gz" -> "tar.gz"; not "gz")
+        basename, dot, ext = filename.partition(".")
+
+    before, sep, after = basename.rpartition(insert)
+    if not sep:
+        before, sep, after = after, insert, "0"
+    try:
+        after_int = int(after)
+    except ValueError:
+        # If the "after" is not an integer, we need to tack on our own int.
+        before = before + sep + after
+        after_int = 0
+    return f"{before}{insert}{after_int + 1}{dot}{ext}"
+
+
+def is_remote(path: str) -> bool:
+    """Returns true if a path is remote; false if not.
+
+    >>> is_remote("cloud/cuckooland")
+    True
+    >>> is_remote("cloud/clod/clone/clue/clip")
+    True
+    >>> is_remote("my/home/directory")
+    False
+    """
+    return path.split("/")[0] == "cloud"
+
+
+def is_remote_dir(path: str) -> bool:
+    """Returns true if the path is a remote directory; false if not.
+
+    >>> is_remote_dir("cloud/owned")
+    True
+    >>> is_remote_dir("cloud/disowned")
+    False
+    >>> is_remote_dir("cloud/public/something")
+    True
+    >>> is_remote_dir("cloud/shared/too/many/slashes")
+    False
+    """
+    splits = path.split("/")
+    if splits[0] != "cloud":
+        return False
+    if len(splits) == 1:
+        return True
+    if 3 < len(splits):
+        return False
+    return splits[1] in ("owned", "public", "shared")
+
+
+def remove_prefix(path_prefix: str, path: str) -> str:
+    """Removes a prefix and everything that comes before it from a path.
+
+    >>> remove_prefix("and", "here and there")
+    ' there'
+    >>> remove_prefix("missing", "some other string")
+    'some other string'
+    """
+    before, _, after = path.partition(path_prefix)
+    return after or before
+
+
+def extract_category(path: str) -> Optional[str]:
+    """Pulls the category out of a Cloud path.
+
+    >>> extract_category("cloud/owned/me/my-array")
+    'owned'
+    >>> extract_category("local/path/to/array")
+    >>> extract_category("cloud")
+    """
+    parts = path.split("/")
+    if parts[0] != "cloud":
+        return None
+    try:
+        return parts[1]
+    except IndexError:
+        return None
+
+
+def extract_namespace(path: str) -> Optional[str]:
+    """Pulls the namespace out of a Cloud path.
+
+    >>> extract_namespace("cloud/owned/me/my-array")
+    'me'
+    >>> extract_namespace("local/path/to/array")
+    >>> extract_namespace("cloud/owned")
+    """
+    parts = path.split("/")
+    if parts[0] != "cloud":
+        return None
+    try:
+        return parts[2]
+    except IndexError:
+        return None

--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -1127,29 +1127,6 @@ class TileDBCloudContentsManager(TileDBContents, filemanager.FileContentsManager
 
         return model
 
-    def __group_to_models(self, path_prefix, paths):
-        """
-        Applies _notebook_model_from_s3_path or _file_model_from_s3_path to each entry of `paths`,
-        depending on the result of `guess_type`.
-        """
-        ret = []
-        for path in paths:
-            # path = remove_path_prefix("file://" + os.getcwd() + "/", path)
-            # path_after = remove_path_prefix(path_prefix, path)
-            # path = path_after
-            # if os.path.basename(path) == self.dir_keep_file:
-            #      continue
-            type_ = self.guess_type(path, allow_directory=True)
-            if type_ == "notebook":
-                ret.append(self._notebook_from_array(path, False))
-            elif type_ == "file":
-                ret.append(self._file_from_array(path, False, None))
-            elif type_ == "directory":
-                ret.append(self.__directory_model_from_path(path, False))
-            else:
-                tornado.web.HTTPError(500, "Unknown file type %s for file '%s'" % (type_, path))
-        return ret
-
     def get(self, path, content=True, type=None, format=None):
         """Get a file or directory model."""
         path_fixed = path.strip("/")


### PR DESCRIPTION
This branch, best reviewed commit-by-commit (it’s not as scary as it looks!), starts to break up the monolithic tiledbcloudcontents.py file into a few more cohesive modules, along with a few other cleanups. More details are found in each commit, but in broad strokes, it:

- Simplifies use and comparison of datetimes
- Removes unused code
- Pulls caching and path manipulation out into their own modules (`caching.py` and `paths.py`, respectively).