### PR TITLE
More (the last?) cleanup and modularization of tiledbcontents.

### DIFF
--- a/tiledbcontents/arrays.py
+++ b/tiledbcontents/arrays.py
@@ -1,0 +1,280 @@
+"""Functions which handle accessing arrays, local and remote."""
+
+import os
+import time
+from typing import Optional, Tuple
+
+import numpy
+import tiledb.cloud
+import tornado.web
+
+from . import caching
+from . import paths
+
+JUPYTER_IMAGE_NAME_ENV = "JUPYTER_IMAGE_NAME"
+JUPYTER_IMAGE_SIZE_ENV = "JUPYTER_IMAGE_SIZE"
+
+
+def exists(path: str) -> bool:
+    """Checks if an array exists in TileDB Cloud."""
+    tdb_uri = paths.tiledb_uri_from_path(path)
+    try:
+        tiledb.cloud.array.info(tdb_uri)
+        return True
+    except tiledb.cloud.TileDBCloudError:
+        pass
+    return False
+
+
+def fetch_type(uri: str) -> Optional[str]:
+    try:
+        arr = caching.Array.from_cache(uri)
+    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+        raise tornado.web.HTTPError(500, f"Error getting type: {e}") from e
+    except tiledb.TileDBError as e:
+        raise tornado.web.HTTPError(500, str(e)) from e
+    except Exception as e:
+        raise tornado.web.HTTPError(400, f"Error getting file type: {e}") from e
+    try:
+        return arr.cached_meta["type"]
+    except KeyError:
+        return None
+
+
+def write_bytes(
+    path: str,
+    contents: numpy.ndarray,
+    *,
+    mimetype: Optional[str] = None,
+    format: Optional[str] = None,
+    type: Optional[str] = None,
+    s3_prefix: Optional[str] = None,
+    s3_credentials: Optional[str] = None,
+    is_user_defined_name: bool = False,
+    is_new: bool = False,
+) -> Optional[str]:
+    """Writes the given bytes to the array. Will create the array if it doesn't exist.
+
+    :param uri: The URI of the array to write to.
+    :param contents: The bytes to write.
+    :param mimetype: The MIME type to set in the metadata.
+    :param format: The format to set in the metadata.
+    :param s3_prefix: The S3 path to write to.
+    :param s3_credentials: The name within TileDB Cloud of the s3 credentials
+        to use when writing to the ``s3_prefix``.
+    :param is_user_defined_name: True to indicate that the user provided
+        the given filename. False to indicate that it was generated.
+    :param is_new: True if we are creating a new array, false if we are writing
+        to an existing array.
+    :return: If creating a new array, the name of that newly-created array.
+        If writing to an existing array, None.
+    """
+    tiledb_uri = paths.tiledb_uri_from_path(path)
+    final_array_name = None
+    if is_new:
+        # if not arrays.exists(uri):
+        tiledb_uri, final_array_name = create(
+            tiledb_uri,
+            retry=5,
+            s3_prefix=s3_prefix,
+            s3_credentials=s3_credentials,
+            is_user_defined_name=is_user_defined_name,
+        )
+
+    with tiledb.open(tiledb_uri, mode="w", ctx=caching.CLOUD_CONTEXT) as arr:
+        arr[0:len(contents)] = {"contents": contents}
+        arr.meta["file_size"] = len(contents)
+        if mimetype is not None:
+            arr.meta["mimetype"] = mimetype
+        if format is not None:
+            arr.meta["format"] = format
+        if type is not None:
+            arr.meta["type"] = type
+
+    caching.Array.from_cache(tiledb_uri, {"contents": contents})
+
+    return final_array_name
+
+
+def create(
+    path: str,
+    *,
+    retry: int = 0,
+    s3_prefix: Optional[str] = None,
+    s3_credentials: Optional[str] = None,
+    is_user_defined_name: bool = False,
+) -> Tuple[str, str]:
+    """Creates a new array for storing a notebook file.
+
+    :param uri: The location to create the array.
+    :param retry: The number of times to retry the request if it fails.
+    :param s3_prefix: The S3 path to write to.
+    :param s3_credentials: The name within TileDB Cloud of the S3 credentials
+        to use when writing to the ``s3_prefix``.
+    :param is_user_defined_name: True to indicate that the user provided
+        the given filename. False to indicate that it was generated.
+    :return: A tuple of (the TileDB URI, the name of the array)
+    """
+    while True:
+        try:
+            parts = paths.split(path)
+            namespace = parts[-2]
+            array_name = parts[-1] + "_" + paths.generate_id()
+
+            # Use the general cloud context by default.
+            tiledb_create_context = caching.CLOUD_CONTEXT
+
+            # Retrieving credentials is optional
+            # If None, default credentials will be used
+            s3_credentials = s3_credentials or _namespace_s3_credentials(namespace)
+
+            if s3_credentials is not None:
+                # update context with config having header set
+                tiledb_create_context = tiledb.cloud.Ctx({
+                    "rest.creation_access_credentials_name": s3_credentials,
+                })
+            # The array will be be 1 dimensional with domain of 0 to max uint64. We use a tile extent of 1024 bytes
+            dom = tiledb.Domain(
+                tiledb.Dim(
+                    name="position",
+                    domain=(0, numpy.iinfo(numpy.uint64).max - 1025),
+                    tile=1024,
+                    dtype=numpy.uint64,
+                    ctx=tiledb_create_context,
+                ),
+                ctx=tiledb_create_context,
+            )
+
+            schema = tiledb.ArraySchema(
+                domain=dom,
+                sparse=False,
+                attrs=[
+                    tiledb.Attr(
+                        name="contents",
+                        dtype=numpy.uint8,
+                        filters=tiledb.FilterList([tiledb.ZstdFilter()]),
+                    )
+                ],
+                ctx=tiledb_create_context,
+            )
+
+            if is_user_defined_name:
+                array_name = parts[-1]
+            else:
+                array_name = parts[-1] + "_" + paths.generate_id()
+
+            if namespace in paths.RESERVED_NAMES:
+                raise tornado.web.HTTPError(
+                    403,
+                    f"{namespace!r} is not a valid folder to create notebooks. "
+                    "Please select a proper namespace (username or organization name).",
+                )
+
+            s3_prefix = s3_prefix or _namespace_s3_prefix(namespace)
+            if s3_prefix is None:
+                raise tornado.web.HTTPError(
+                    403,
+                    "You must set the default s3 prefix path for notebooks "
+                    f"in {namespace} profile settings",
+                )
+
+            tiledb_uri_s3 = "tiledb://" + paths.join(namespace, s3_prefix, array_name)
+
+            # Create the (empty) array on disk.
+            tiledb.DenseArray.create(tiledb_uri_s3, schema)
+
+            tiledb_uri = "tiledb://" + paths.join(namespace, array_name)
+            time.sleep(0.25)
+
+            file_properties = {}
+            # Get image name from env if exists
+            # This is stored as a tag for TileDB Cloud for searching, filtering and launching
+            image_name = os.getenv(JUPYTER_IMAGE_NAME_ENV)
+            if image_name is not None:
+                file_properties[
+                    tiledb.cloud.rest_api.models.FilePropertyName.IMAGE
+                ] = image_name
+
+            # Get image size from env if exists
+            # This is stored as a tag for TileDB Cloud for searching, filtering and launching
+            image_size = os.getenv(JUPYTER_IMAGE_SIZE_ENV)
+            if image_size is not None:
+                file_properties[
+                    tiledb.cloud.rest_api.models.FilePropertyName.SIZE
+                ] = image_size
+
+            tiledb.cloud.array.update_info(uri=tiledb_uri, array_name=array_name)
+
+            tiledb.cloud.array.update_file_properties(
+                uri=tiledb_uri,
+                file_type=tiledb.cloud.rest_api.models.FileType.NOTEBOOK,
+                # If file_properties is empty, don't send anything at all.
+                file_properties=file_properties or None,
+            )
+
+            return tiledb_uri, array_name
+        except tiledb.TileDBError as e:
+            if "Error while listing with prefix" in str(e):
+                # It is possible to land here if user sets wrong default s3 credentials with respect to default s3 path
+                raise tornado.web.HTTPError(
+                    400, f"Error creating file: {e}. Are your credentials valid?"
+                ) from e
+
+            if "already exists" in str(e):
+                # OK, let's try incrementing the filename.
+                parts = paths.split(path)
+                array_name = parts[-1]
+
+                array_name = paths.increment_filename(array_name)
+
+                parts[-1] = array_name
+                path = paths.join(*parts)
+                # This doesn't count as a retry.
+            elif retry:
+                retry -= 1
+            else:
+                # We're out of retries.
+                raise
+        except tornado.web.HTTPError:
+            # HTTPErrors are all errors that we raise ourselves,
+            # so just reraise them.
+            raise
+        except Exception as e:
+            raise tornado.web.HTTPError(400, f"Error creating file: {e}") from e
+
+
+def _namespace_s3_prefix(namespace: str) -> Optional[str]:
+    """Fetches the default S3 path prefix from the user or organization profile."""
+    try:
+        profile = tiledb.cloud.client.user_profile()
+
+        if namespace == profile.username:
+            if profile.default_s3_path is not None:
+                return paths.join(profile.default_s3_path, "notebooks")
+            return None
+        organization = tiledb.cloud.client.organization(namespace)
+        if organization.default_s3_path is not None:
+            return paths.join(organization.default_s3_path, "notebooks")
+        return None
+    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+        raise tornado.web.HTTPError(
+            400,
+            f"Error fetching user default s3 path for new notebooks {e}"
+        ) from e
+
+
+def _namespace_s3_credentials(namespace: str) -> Optional[str]:
+    """Fetches the default S3 credentials from the user or organization profile."""
+    try:
+        profile = tiledb.cloud.client.user_profile()
+
+        if namespace == profile.username:
+            return profile.default_s3_path_credentials_name
+        organization = tiledb.cloud.client.organization(namespace)
+        return organization.default_s3_path_credentials_name
+    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+        raise tornado.web.HTTPError(
+            400,
+            f"Error fetching default credentials for {namespace!r} default "
+            f"s3 path for new notebooks: {e}",
+        ) from e

--- a/tiledbcontents/caching.py
+++ b/tiledbcontents/caching.py
@@ -1,12 +1,14 @@
 """Tools to handle caching of TileDB arrays and listings."""
 
 import time
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Dict, Optional, Tuple, Type
 
 import tiledb
 import tiledb.cloud
 import tiledb.cloud.client
 import tornado.web
+
+from . import models
 
 CLOUD_CONTEXT = tiledb.cloud.Ctx()
 
@@ -14,7 +16,7 @@ CLOUD_CONTEXT = tiledb.cloud.Ctx()
 class Array:
     """Caching wrapper around a TileDB Array."""
 
-    def __init__(self, uri: str, contents: Optional[Dict[str, Any]] = None):
+    def __init__(self, uri: str, contents: Optional[models.Model] = None):
         """
         Create an Array wrapping a TileDB Array class
         :param uri:
@@ -25,10 +27,10 @@ class Array:
         except Exception as e:
             raise tornado.web.HTTPError(400, f"Error in Array init: {e}") from e
         self.contents_fetched = False
-        self.cached_meta: Dict[str, Any] = {}
+        self.cached_meta: models.Model = {}
         self.cache_metadata()
         # Cache contents if exist during first array write
-        self.cached_contents: Optional[Dict[str, Any]] = contents
+        self.cached_contents: Optional[models.Model] = contents
 
     # A global cache of Arrays by URI.
     _cache: Dict[str, "Array"] = {}
@@ -47,7 +49,7 @@ class Array:
     def purge(cls: Type["Array"], uri: str) -> None:
         cls._cache.pop(uri, None)
 
-    def read(self) -> Optional[Dict[str, Any]]:
+    def read(self) -> Optional[models.Model]:
         """
         Fetch all contents of the array based on file_size metadata field
         :return: raw bytes of content
@@ -101,6 +103,8 @@ _CATEGORY_LOADERS = {
     "shared": tiledb.cloud.client.list_shared_arrays,
     "public": tiledb.cloud.client.list_public_arrays,
 }
+
+CATEGORIES = frozenset(_CATEGORY_LOADERS)
 
 _CACHE_SECS = 4
 

--- a/tiledbcontents/listings.py
+++ b/tiledbcontents/listings.py
@@ -1,0 +1,212 @@
+"""Functions that list contents on the remote server."""
+
+import tiledb.cloud
+import tornado.web
+
+from typing import Any, List
+
+from . import caching
+from . import models
+from . import paths
+
+
+def namespace(category: str, namespace: str, *, content: bool = False) -> models.Model:
+    """Lists all notebook arrays in a namespace, like an `ls`.
+
+    :param category: The category to list; one of "shared", "owned", or "public"
+    :param namespace: The namespace to list
+    :param content: True to include contents, False to not.
+    :return: A model of the namespace.
+    """
+    arrays = []
+    try:
+        listing = caching.ArrayListing.from_cache(category, namespace)
+        arrays = listing.arrays()
+    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+        raise tornado.web.HTTPError(
+            500, "Error listing notebooks in {}: {}".format(namespace, str(e))
+        )
+    except tiledb.TileDBError as e:
+        raise tornado.web.HTTPError(
+            500,
+            str(e),
+        )
+    except Exception as e:
+        raise tornado.web.HTTPError(
+            400,
+            "Error listing notebooks in  {}: {}".format(namespace, str(e)),
+        )
+
+    model = models.create(
+        path=paths.join("cloud", category, namespace),
+        type="directory",
+    )
+    if content:
+        # Build model content if asked for
+        model["format"] = "json"
+        model["content"] = []
+        if arrays is not None:
+            for notebook in arrays:
+                nbmodel = models.create(path=notebook.name)
+
+                # Add notebook extension to name, so jupyterlab will open with as a notebook
+                # It seems to check the extension even though we set the "type" parameter
+                nbmodel["path"] = "cloud/{}/{}/{}{}".format(
+                    category, namespace, nbmodel["path"], paths.NOTEBOOK_EXT
+                )
+
+                nbmodel["last_modified"] = models.to_utc(notebook.last_accessed)
+                # Update namespace directory based on last access notebook
+                _maybe_update_last_modified(model, notebook)
+
+                nbmodel["type"] = "notebook"
+
+                if (
+                    notebook.allowed_actions is None
+                    or "write" not in notebook.allowed_actions
+                ):
+                    model["writable"] = False
+                model["content"].append(nbmodel)
+
+    return model
+
+
+def category(category: str, *, content: bool = True) -> models.Model:
+    """Lists the directories within a category.
+
+    :param category: The category to list; one of "shared", "owned", or "public"
+    :param content: True to include contents, False to not.
+    :return: A directory model for the category.
+    """
+    # TODO: This function should be switched to use sidebar data.
+    arrays = []
+    try:
+        arrays = caching.ArrayListing.from_cache(category).arrays()
+    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+        raise tornado.web.HTTPError(
+            500, "Error listing notebooks in {}: {}".format(category, str(e))
+        )
+    except tiledb.TileDBError as e:
+        raise tornado.web.HTTPError(
+            500,
+            str(e),
+        )
+    except Exception as e:
+        raise tornado.web.HTTPError(
+            400,
+            "Error listing notebooks in  {}: {}".format(category, str(e)),
+        )
+
+    model = models.create(path=paths.join("cloud", category), type="directory")
+    if content:
+        model["format"] = "json"
+        model["content"] = []
+        namespaces = {}
+        if category == "owned":
+            # For owned, we should always list the user and their
+            # organizations. If there is actual notebooks they will be
+            # listed below. This base listing is so users can create new
+            # notebooks in any of the namespaces they are part of.
+            try:
+                profile = tiledb.cloud.client.user_profile()
+                namespace_model = models.create(
+                    path=paths.join("cloud", category, profile.username),
+                    type="directory",
+                    format="json",
+                )
+                namespaces[profile.username] = namespace_model
+
+                for org in profile.organizations:
+                    # Don't list public for owned
+                    if org.organization_name == "public":
+                        continue
+
+                    namespace_model = models.create(
+                        path=paths.join("cloud", category, org.organization_name),
+                        type="directory",
+                        format="json",
+                    )
+
+                    namespaces[org.organization_name] = namespace_model
+
+            except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+                raise tornado.web.HTTPError(
+                    500,
+                    "Error listing notebooks in {}: {}".format(category, str(e)),
+                )
+            except tiledb.TileDBError as e:
+                raise tornado.web.HTTPError(
+                    500,
+                    str(e),
+                )
+            except Exception as e:
+                raise tornado.web.HTTPError(
+                    400,
+                    "Error listing notebooks in  {}: {}".format(category, str(e)),
+                )
+
+        # If the arrays are non-empty list them out
+        if arrays is not None:
+            for notebook in arrays:
+                if notebook.namespace not in namespaces:
+                    namespace_model = models.create(
+                        path=paths.join("cloud", category, notebook.namespace),
+                        type="directory",
+                        format="json",
+                        writable=False,
+                    )
+                    namespaces[notebook.namespace] = namespace_model
+
+                # Update directory based on last access notebook
+                _maybe_update_last_modified(model, notebook)
+
+                # Update namespace directory based on last access notebook
+                _maybe_update_last_modified(namespaces[notebook.namespace], notebook)
+
+        model["content"] = list(namespaces.values())
+
+    return model
+
+
+def all_notebooks() -> List[models.Model]:
+    """List all notebooks, across all categories."""
+    try:
+        return [_all_notebooks_in(cat) for cat in caching.CATEGORIES]
+    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+        raise tornado.web.HTTPError(
+            500, f"Error building cloud notebook info: {e}"
+        ) from e
+    except tiledb.TileDBError as e:
+        raise tornado.web.HTTPError(500, str(e)) from e
+    except Exception as e:
+        raise tornado.web.HTTPError(
+            500, f"Error building cloud notebook info: {e}"
+        ) from e
+
+
+def _all_notebooks_in(category: str) -> models.Model:
+    model = models.create(path=paths.join("cloud", category), type="directory")
+    listing = caching.ArrayListing.from_cache(category)
+    notebooks = listing.arrays()
+    if notebooks:
+        model.update(
+            format="json",
+            content=[],
+        )
+        for notebook in notebooks:
+            nb_model = models.create(
+                path=notebook.name,
+                type="notebook",
+                format="json",
+                last_modified=models.to_utc(notebook.last_accessed),
+            )
+            nb_model["path"] = paths.join(category, model["path"] + paths.NOTEBOOK_EXT)
+            model["content"].append(nb_model)
+            _maybe_update_last_modified(model, notebook)
+    return model
+
+
+def _maybe_update_last_modified(model: models.Model, notebook: Any) -> None:
+    nb_last_acc = models.to_utc(notebook.last_accessed)
+    md_last_mod = models.to_utc(model["last_modified"])
+    model["last_modified"] = max(nb_last_acc, md_last_mod)

--- a/tiledbcontents/models.py
+++ b/tiledbcontents/models.py
@@ -1,0 +1,38 @@
+"""Dealing with models."""
+
+import datetime
+from typing import Dict, Any
+import posixpath
+
+DUMMY_DATE = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
+
+Model = Dict[str, Any]
+
+
+def create(*, path: str, **kwargs: Any) -> Model:
+    """Create the most basic model."""
+    # Originally from:
+    # https://github.com/danielfrg/s3contents/blob/master/s3contents/genericmanager.py
+    model = {
+        "name": posixpath.basename(path),
+        "path": path,
+        "writable": True,
+        "last_modified": DUMMY_DATE,
+        "created": DUMMY_DATE,
+        "content": None,
+        "format": None,
+        "mimetype": None,
+    }
+    model.update(**kwargs)
+    return model
+
+
+def to_utc(d: datetime.datetime) -> datetime.datetime:
+    """Returns a version of d converted to UTC.
+
+    If naive (no timezone), UTC will be added; if timezone-aware, the time
+    will be converted.
+    """
+    if not d.tzinfo:
+        return d.replace(tzinfo=datetime.timezone.utc)
+    return d.astimezone(datetime.timezone.utc)


### PR DESCRIPTION
Yes, it’s another cleanup change, once again best read one commit as a time.

Overall, this separates the code into:

- arrays.py, which deals directly with the reading and writing of arrays
- listings.py, which deals with file lists
- models.py, which has mostly a few leftovers that are used when creating or manipulating models

It also adds a few more things into paths.py and performs an assortment of other related cleanups along the way.

After this change, all of what remains in the various `ContentManager` classes is only the stuff that actually depends on other things within the `ContentsManager`, with no methods that are completely independent of the instance’s state (i.e., there are no methods which don’t use `self`), and tiledbcontents.py contains essentially only the code that is needed to wire the other packages back into the relevant Jupyter plugin APIs.

I’ve tested locally against my own TileDB Cloud account, and everything still works great.

(Setting this up was extremely frustrating because, based on Jupyter’s own documentation, I had removed the seemingly-unnecessary `strip` calls. They *were* necessary, so they are back, this time with a description of *why* they are necessary—because the documentation tells dirty lies.)