### PR TITLE
Add support for uploading notebooks to TileDB Cloud (!)

### DIFF
--- a/tiledbcontents/arrays.py
+++ b/tiledbcontents/arrays.py
@@ -119,7 +119,6 @@ def create(
         try:
             parts = paths.split(path)
             namespace = parts[-2]
-            array_name = parts[-1] + "_" + paths.generate_id()
 
             # Use the general cloud context by default.
             tiledb_create_context = caching.CLOUD_CONTEXT


### PR DESCRIPTION
This change fixes the bug that prevented us from uploading Jupyter
notebooks even after we stopped treating them like other files.

- Creates a `tiledb:is_new` field on the model when creating a new
  notebook, so we know when a notebook is, uh, new.
- Puts all TileDB-specific variables in a `tiledb:` namespace on the
  model to avoid potential collisions.
- Minor cleanups.

Also fixes a bug where we would never fetch new directory listings after startup.