### PR TITLE
Increment the filename when creating new local files.

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import posixpath
 
 import nbformat
 import numpy
@@ -354,6 +355,12 @@ class TileDBCloudContentsManager(TileDBContents, filemanager.FileContentsManager
             raise tornado.web.HTTPError(400, "Unhandled contents type: %s" % model["type"])
 
         if not paths.is_remote(path):
+            if model.get("tiledb:is_new"):
+                # Since we don't try to increment the filename in self.new(),
+                # do it here for newly-created files.
+                dir, name = posixpath.split(path)
+                incremented = self.increment_filename(name, dir, insert='-')
+                path = paths.join(dir, incremented)
             return super().save(model, path)
 
         if path.endswith(paths.NOTEBOOK_EXT):


### PR DESCRIPTION
Commit cd17208815e3eb7cf31fb6120272341439dac35c introduced a regression
where, because creating notebooks in local storage did not try to
increment the filename, a new untitled file would end up overwriting
an existing file of the same name rather than creating, e.g.
"Untitled-2".

This change restores the name-incrementation step for newly-created
local files.