### PR TITLE
Remove obsolete content-type parameter from `delete_array`.

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -413,9 +413,7 @@ class TileDBCloudContentsManager(TileDBContents, filemanager.FileContentsManager
             tiledb_uri = paths.tiledb_uri_from_path(path)
             try:
                 caching.Array.purge(tiledb_uri)
-                return tiledb.cloud.array.delete_array(
-                    tiledb_uri, "application/x-ipynb+json"
-                )
+                return tiledb.cloud.array.delete_array(tiledb_uri)
             except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
                 raise tornado.web.HTTPError(
                     500, f"Error deregistering {tiledb_uri!r}: {e}"


### PR DESCRIPTION
In this change:

https://github.com/TileDB-Inc/TileDB-Cloud-Py/commit/496ccb21c59c344e1540a1650b95c2feae84f788

we removed the unnecessary content-type parameter from the
`delete_array` function. We also have to update this call site.