### PR TITLE
Set a `last_modified` value on directory models if absent.

### DIFF
--- a/tiledbcontents/listings.py
+++ b/tiledbcontents/listings.py
@@ -200,7 +200,8 @@ def _all_notebooks_in(category: str) -> models.Model:
                 format="json",
                 last_modified=models.to_utc(notebook.last_accessed),
             )
-            nb_model["path"] = paths.join(category, model["path"] + paths.NOTEBOOK_EXT)
+            nb_model["path"] = paths.join(
+                category, nb_model["path"] + paths.NOTEBOOK_EXT)
             model["content"].append(nb_model)
             _maybe_update_last_modified(model, notebook)
     return model

--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -341,10 +341,12 @@ class TileDBCloudContentsManager(TileDBContents, filemanager.FileContentsManager
                 return self._file_from_array(path, content=content, format=format)
             if type == "directory":
                 dir_model = self._directory_model_from_path(path, content=content)
-                if dir_model.get("last_modified") is None:
-                    dir_model["last_modified"] = models.to_utc(
-                        datetime.datetime.utcnow()
-                    )
+                # Jupyter chokes when either of these are missing or `null`
+                # in its returned object. We use a fake value if absent.
+                now = datetime.datetime.now(tz=datetime.timezone.utc)
+                for prop in ("last_modified", "created"):
+                    if dir_model.get(prop) is None:
+                        dir_model[prop] = now
                 return dir_model
         except Exception as e:
             raise tornado.web.HTTPError(

--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -1,18 +1,19 @@
 import base64
+import datetime
 import json
 import posixpath
 from typing import List
 
 import nbformat
+from notebook.services.contents import checkpoints
+from notebook.services.contents import filecheckpoints
+from notebook.services.contents import filemanager
+from notebook.services.contents import manager
 import numpy
 import tiledb
 import tiledb.cloud
 import tornado.web
 import traitlets
-from notebook.services.contents import checkpoints
-from notebook.services.contents import filecheckpoints
-from notebook.services.contents import filemanager
-from notebook.services.contents import manager
 
 from . import arrays
 from . import caching
@@ -336,12 +337,15 @@ class TileDBCloudContentsManager(TileDBContents, filemanager.FileContentsManager
 
             if type == "notebook":
                 return self._notebook_from_array(path, content=content)
-            elif type == "file":
+            if type == "file":
                 return self._file_from_array(path, content=content, format=format)
-            elif type == "directory":
-                return self._directory_model_from_path(path, content=content)
-                # if model is not None:
-                #     model.
+            if type == "directory":
+                dir_model = self._directory_model_from_path(path, content=content)
+                if dir_model.get("last_modified") is None:
+                    dir_model["last_modified"] = models.to_utc(
+                        datetime.datetime.utcnow()
+                    )
+                return dir_model
         except Exception as e:
             raise tornado.web.HTTPError(
                 500, "Error opening notebook {}: {}".format(path, str(e))


### PR DESCRIPTION
When attempting to serve a directory within JupyterLab (Hub?),
the `notebook` package unconditionally attempts to set a `Last-Modified`
header based on the `last_modified` key in the directory model.
This would fail if we served a directory which we did not have
`Last-Modified` info for:

    Traceback (most recent call last):
      File ".../site-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File ".../site-packages/tornado/gen.py", line 775, in run
        yielded = self.gen.send(value)
      File ".../site-packages/notebook/services/contents/handlers.py", line 120, in get
        self._finish_model(model, location=False)
      File ".../site-packages/notebook/services/contents/handlers.py", line 91, in _finish_model
        self.set_header('Last-Modified', model['last_modified'])
      File ".../site-packages/tornado/web.py", line 374, in set_header
        self._headers[name] = self._convert_header_value(value)
      File ".../site-packages/tornado/web.py", line 416, in _convert_header_value
        raise TypeError("Unsupported header value %r" % value)
    TypeError: Unsupported header value None

This change adds a last-modified value of Right Now if there is not one
set already.