### PR TITLE
Use a long-ago date when filling in missing datetimes.

### DIFF
--- a/tiledbcontents/models.py
+++ b/tiledbcontents/models.py
@@ -54,19 +54,25 @@ def max_present(stuff: Iterable[Optional[_T]]) -> Optional[_T]:
         return None
 
 
+_DUMMY_DATE = datetime.datetime(2014, 11, 1, 1, 14, 33, tzinfo=datetime.timezone.utc)
+"""A dummy date we use to fill in models where Jupyter requires one.
+
+The significance of this date is left as an exercise for the reader.
+"""
+
+
 def fill_in_dates(m: Model) -> Model:
     """Fills in the ``created`` and ``last_modified`` fields if empty.
 
     Many parts of Jupyter throw a temper tantrum if either the ``created`` field
     or the ``last_modified`` field of a model is empty.  If either is missing,
-    we replace it with now.
+    we replace it with a dummy.
 
     Modifies and returns the passed-in object, so you can use it like:
 
         return fill_in_dates(build_model())
     """
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
     for prop in ("last_modified", "created"):
         if m.get(prop) is None:
-            m[prop] = now
+            m[prop] = _DUMMY_DATE
     return m


### PR DESCRIPTION
Previously, we learned that Jupyter REALLY REALLY WANTS to know the
creation and modification dates of every single thing it touches
and is NOT satisfied with being told that said information simply
does not exist. So we decided to just tell it "OK, the time is now.
Are you happy?" And initially, it did seem happy! We could successfully
browse and open and all the file operations we love to do so much,
so far as we could tell. But then, we found out that there were,
in fact, Problems.

Jupyter (sensibly) uses the last-modification date to check for edit
races, so that if you make a change but the file changes out under you
(i.e., its edit date changes since the time that you opened it),
it gives you a warning that you may be overwriting others' changes.
Given that we were always telling Jupyter that the last-modified time
was Right Now, Jupyter would always think that the file had been changed
and warn the user that they might be overwriting existing changes.

So now tell Jupyter a different lie: if we don't know what time
something happened at, we just say it was an arbitrary time
in the past. (That arbitrary time happens to be the timestamp of
f7f1165d96766ae311183d7c2912b1eff2a5451b, the first commit
to the TileDB core repository.)