### PR TITLE
Force purge of cache when a file is uploaded.

### DIFF
--- a/tiledbcontents/arrays.py
+++ b/tiledbcontents/arrays.py
@@ -98,7 +98,7 @@ def write_bytes(
         if type is not None:
             arr.meta["type"] = type
 
-    caching.Array.from_cache(tiledb_uri, {"contents": contents})
+    caching.Array.force_create(tiledb_uri, {"contents": contents})
 
     return final_array_name
 

--- a/tiledbcontents/caching.py
+++ b/tiledbcontents/caching.py
@@ -36,13 +36,18 @@ class Array:
     _cache: Dict[str, "Array"] = {}
 
     @classmethod
-    def from_cache(cls: Type["Array"], uri: str, *args, **kwargs) -> "Array":
+    def force_create(cls: Type["Array"], uri: str, *args, **kwargs) -> "Array":
+        cls._cache[uri] = cls(uri, *args, **kwargs)
+        return cls._cache[uri]
+
+    @classmethod
+    def from_cache(cls: Type["Array"], uri: str) -> "Array":
         """Fetches an Array from the cache, or constructs a new one if not present."""
         try:
             return cls._cache[uri]
         except KeyError:
             pass
-        cls._cache[uri] = cls(uri, *args, **kwargs)
+        cls._cache[uri] = cls(uri)
         return cls._cache[uri]
 
     @classmethod


### PR DESCRIPTION
This should (?) fix a bug where uploading a notebook will not work
properly due to the a stale cache entry.