### PR TITLE
Simplify caching layer and make it async-aware.

### DIFF
--- a/tiledbcontents/paths.py
+++ b/tiledbcontents/paths.py
@@ -67,6 +67,8 @@ def is_remote(path: str) -> bool:
     True
     >>> is_remote("my/home/directory")
     False
+    >>> is_remote("/cloud/lol")
+    True
     """
     return split(strip(path))[0] == "cloud"
 
@@ -147,7 +149,7 @@ def split(path: str) -> List[str]:
     >>> split("")
     ['']
     """
-    return path.split(posixpath.sep)
+    return strip(path).split(posixpath.sep)
 
 
 def strip(path: str) -> str:


### PR DESCRIPTION
This updates the caching layer to only cache metadata rather than also
holding onto array contents and an opened Array. This is because,
empirically, jupyter (no longer?) does a read immediately after a write,
which was the rationale for caching notebook contents.

Instead, we only open the array as needed to read/write it, and load
and update metadata at those times. This (and some other functions)
now run in an async-aware manner, putting only the blocking I/O onto
a worker thread and managing all other data in the main event loop.