### PR TITLE
Make downloading work right (again? for the first time?)

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -3,9 +3,10 @@ import json
 import posixpath
 from typing import List
 
-import nbformat
+import jupyter_server.files.handlers as jsfh
 from jupyter_server.services.contents import filecheckpoints
 from jupyter_server.services.contents import filemanager
+import nbformat
 import tiledb
 import tiledb.cloud
 import tornado.web
@@ -27,6 +28,12 @@ class AsyncTileDBCloudContentsManager(
 ):
     # This makes the checkpoints get saved on this directory
     root_dir = traitlets.Unicode("./", config=True)
+
+    # These are needed to reset the file downloader so that it actually works
+    # rather than intercepting everything with a downloader that is only aware
+    # of the filesystem.
+    files_handler_class = traitlets.Type(jsfh.FilesHandler)
+    files_handler_params = traitlets.Dict({})
 
     @traitlets.default("checkpoints_class")
     def _checkpoints_class_default(self):


### PR DESCRIPTION
The [`Async`]`FileContentsManager` uses a special static content handler to handle file downloads that does not interact with the Jupyter contents manager at all. This meant that when we subclassed it, requests for file downloads (which work differently for requests for notebook contents, because ???) would be intercepted before they even hit the rest of Jupyter meaning that it was nigh impossible to figure out what was going on because even when you did a download, no request would appear in the server-side request logs on stderr.

After way too much digging I eventually figured out about the default files handler class:

https://github.com/jupyter-server/jupyter_server/blob/afb1af03bb17df59ddd1d29ba6baf6be6678d0d3/jupyter_server/services/contents/filemanager.py#L80-L86

and that this is what we needed to override. And this brings us here.