### PR TITLE
Sa/sc 22940/update tiledb2.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIRES = [
     "setuptools-scm>=1.5.4",
     "setuptools>=45",
     "tiledb-cloud>=0.7.44",
-    "tiledb>=0.16.1, !=0.17.5",  # 0.17.5 has a terminal-opening bug.
+    "tiledb>=0.18.0",
     "tornado",
     "traitlets",
 ]


### PR DESCRIPTION
This updates TileDB to 2.12.0

First question: Is this necessary or we can live with 2.11.3?

Second, I want comments on the build procedure i used, i am not a py expert.

I changed setup.py, added 2.12.0 and `pip install .` Then `pip freeze >requirements.txt` and there are many updates to packages.

Should i have edited `requirements.txt` and used `pip -r` to reduce updates of other packages?
