### PR TITLE
Remove suffix striping from guess_type

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -547,8 +547,6 @@ class AsyncTileDBCloudContentsManager(
             if paths.is_remote_dir(path):
                 return "directory"
             else:
-                if path.endswith(paths.NOTEBOOK_EXT):
-                    path = path[: -1 * len(paths.NOTEBOOK_EXT)]
                 try:
                     tiledb_uri = paths.tiledb_uri_from_path(path)
                     return await arrays.fetch_type(tiledb_uri)


### PR DESCRIPTION
The method should not change the path. It is the caller's responsibility to pass a properly stripped path.

Jupyter needs names with the .ipynb suffix but TileDB arrays do not have it by convention. Our code adds the suffix when passing paths to Jupyter and removes it when passing paths back to cloud. If an array name already has .ipynb suffix then guess_type did a second unneeded strip that caused an error. For example

notebook.ipynb is the cloud notebook
notebook.ipynb.ipynb is sent to Jupyter
.. do some jupyter work
notebook.ipynb is about to be sent back
notebook is what guess_type checks

notebook does not exist so we get an error because Jupyter considers it a directory

See https://app.shortcut.com/tiledb-inc/story/25796/notebook-with-ipynb-ipynb-fails-to-load