### PR TITLE
Enable using TileDB array timestamps for remote checkpoints.

### DIFF
--- a/tiledbcontents/paths.py
+++ b/tiledbcontents/paths.py
@@ -11,6 +11,13 @@ NOTEBOOK_EXT = ".ipynb"
 _NB_NO_DOT = NOTEBOOK_EXT[1:]
 
 
+def maybe_trim_ipynb(path: str) -> str:
+    """Removes ``.ipynb`` from the end of ``path``, if present."""
+    if path.endswith(NOTEBOOK_EXT):
+        return path[:-len(NOTEBOOK_EXT)]
+    return path
+
+
 def tiledb_uri_from_path(path: str) -> str:
     """Builds a tiledb:// URI from a notebook cloud path.
 


### PR DESCRIPTION
This reads the fragment timestamps of writes to the array to assemble the list of checkpoints the user can restore to.  Checkpoint IDs are generated (and parsed) based on the timestamp in a human-readable YYYY-MM-DD HHhMM[mSS[sSSS]] format (without showing unnecessary precision when there is no ambiguity).

Verified working in a Jupyter Lab installation.

Context: sc-30786