### PR TITLE
Run all operations which use TileDB Core in a separate process.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@
     TileDB JupyterLab Contents plugin
 """
 
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages
+from setuptools import setup
 
 NAME = "tiledbcontents"
 
@@ -30,7 +31,9 @@ REQUIRES = [
 
 setup(
     name=NAME,
-    description="TileDB Contents Plugin for storing Jupyterlab Notebooks in TileDB Arrays",
+    description="""
+        TileDB Contents Plugin for storing Jupyterlab Notebooks in TileDB Arrays
+    """,
     author_email="hello@tiledb.com",
     url="https://tiledb.com",
     keywords=["TileDB", "cloud", "jupyter", "notebook"],

--- a/tiledbcontents/arrays.py
+++ b/tiledbcontents/arrays.py
@@ -118,11 +118,14 @@ def create(
                 tiledb_create_context = tiledb.cloud.Ctx()
             else:
                 # update context with config having header set
-                tiledb_create_context = tiledb.cloud.Ctx({
-                    "rest.creation_access_credentials_name": s3_credentials,
-                })
+                tiledb_create_context = tiledb.cloud.Ctx(
+                    {
+                        "rest.creation_access_credentials_name": s3_credentials,
+                    }
+                )
 
-            # The array will be be 1 dimensional with domain of 0 to max uint64. We use a tile extent of 1024 bytes
+            # The array will be be 1 dimensional with domain of 0 to max uint64.
+            # We use a tile extent of 1024 bytes.
             dom = tiledb.Domain(
                 tiledb.Dim(
                     name="position",
@@ -192,7 +195,8 @@ def create(
 
             file_properties = {}
             # Get image name from env if exists
-            # This is stored as a tag for TileDB Cloud for searching, filtering and launching
+            # This is stored as a tag for TileDB Cloud for searching, filtering,
+            # and launching.
             image_name = os.getenv(JUPYTER_IMAGE_NAME_ENV)
             if image_name is not None:
                 file_properties[
@@ -200,7 +204,8 @@ def create(
                 ] = image_name
 
             # Get image size from env if exists
-            # This is stored as a tag for TileDB Cloud for searching, filtering and launching
+            # This is stored as a tag for TileDB Cloud for searching, filtering,
+            # and launching.
             image_size = os.getenv(JUPYTER_IMAGE_SIZE_ENV)
             if image_size is not None:
                 file_properties[
@@ -219,7 +224,8 @@ def create(
             return tiledb_uri, array_name
         except tiledb.TileDBError as e:
             if "Error while listing with prefix" in str(e):
-                # It is possible to land here if user sets wrong default s3 credentials with respect to default s3 path
+                # It is possible to land here if user sets the wrong
+                # default credentials with respect to the default storage path.
                 raise tornado.web.HTTPError(
                     400, f"Error creating file: {e}. Are your credentials valid?"
                 ) from e
@@ -242,21 +248,26 @@ def _namespace_s3_prefix(namespace: str) -> Optional[str]:
         profile = tiledb.cloud.client.user_profile()
 
         if namespace == profile.username:
-            if profile.asset_locations.notebooks and profile.asset_locations.notebooks.path:
+            if (
+                profile.asset_locations.notebooks
+                and profile.asset_locations.notebooks.path
+            ):
                 return profile.asset_locations.notebooks.path
             if profile.default_s3_path is not None:
                 return paths.join(profile.default_s3_path, "notebooks")
             return None
         organization = tiledb.cloud.client.organization(namespace)
-        if organization.asset_locations.notebooks and organization.asset_locations.notebooks.path:
+        if (
+            organization.asset_locations.notebooks
+            and organization.asset_locations.notebooks.path
+        ):
             return organization.asset_locations.notebooks.path
         if organization.default_s3_path is not None:
             return paths.join(organization.default_s3_path, "notebooks")
         return None
     except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
         raise tornado.web.HTTPError(
-            400,
-            f"Error fetching user default s3 path for new notebooks {e}"
+            400, f"Error fetching user default s3 path for new notebooks {e}"
         ) from e
 
 
@@ -266,11 +277,17 @@ def _namespace_s3_credentials(namespace: str) -> Optional[str]:
         profile = tiledb.cloud.client.user_profile()
 
         if namespace == profile.username:
-            if profile.asset_locations.notebooks and profile.asset_locations.notebooks.credentials_name:
+            if (
+                profile.asset_locations.notebooks
+                and profile.asset_locations.notebooks.credentials_name
+            ):
                 return profile.asset_locations.notebooks.credentials_name
             return profile.default_s3_path_credentials_name
         organization = tiledb.cloud.client.organization(namespace)
-        if organization.asset_locations.notebooks and organization.asset_locations.notebooks.credentials_name:
+        if (
+            organization.asset_locations.notebooks
+            and organization.asset_locations.notebooks.credentials_name
+        ):
             return organization.asset_locations.notebooks.credentials_name
         return organization.default_s3_path_credentials_name
     except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:

--- a/tiledbcontents/async_tools.py
+++ b/tiledbcontents/async_tools.py
@@ -1,0 +1,120 @@
+"""Stuff used to run TileDB core code asynchronously in another process.
+
+Also includes some miscellaneous utilities.
+"""
+
+
+import asyncio
+import functools
+import os
+import pathlib
+import sys
+import tempfile
+from asyncio import subprocess
+from typing import Callable, Optional, TypeVar
+
+import cloudpickle
+from typing_extensions import ParamSpec, Self
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+async def call(__fn: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    """Calls ``__fn(*args, **kwargs)`` on an executor as to not block.
+
+    If you are making a call which eventually uses the core TileDB library,
+    **do not use this function**! Instead, use ``call_external``, to ensure
+    that your operations are fork-safe.
+    """
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, functools.partial(__fn, *args, **kwargs))
+
+
+_stub_lock = asyncio.Lock()
+"""Lock guarding the creation of the lazy stub."""
+_lazy_stub: Optional["_CallClient"] = None
+"""A lazily-created stub used to make external calls.
+
+Will be initialized the first time ``call_external`` is run.
+"""
+
+
+async def call_external(
+    __fn: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
+) -> _R:
+    """Calls ``__fn(*args, **kwargs)`` in an external process without blocking.
+
+    All calls which go to TileDB Core libraries need to be done in an external
+    process since TileDB Core is not fork-safe, and JupyterLab uses forking
+    to launch terminals.
+
+    All calls sent to this function are handled in separate threads within the
+    same external process.
+    """
+    global _lazy_stub
+    async with _stub_lock:
+        if _lazy_stub is None:
+            _lazy_stub = await _CallClient.create()
+    return await _lazy_stub.run(__fn, *args, **kwargs)
+
+
+class _CallClient:
+    """Stub to run callables in an external process."""
+
+    def __init__(self, proc: subprocess.Process, addr: pathlib.Path) -> None:
+        """Basic initializer. Use ``.create()`` to build a usable instance."""
+        self._proc = proc
+        """The async subprocess that is handling calls."""
+        self._addr = addr
+        """The socket address to write to."""
+
+    async def run(
+        self, __fn: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R:
+        """Calls ``__fn(*args, **kwargs)`` in an external process."""
+        reader, writer = await asyncio.open_unix_connection(self._addr)
+        call = functools.partial(__fn, *args, **kwargs)
+        cloudpickle.dump(call, writer)
+        await writer.drain()
+        writer.write_eof()
+        resp_bytes = await reader.read()
+        response = cloudpickle.loads(resp_bytes)
+        return response.result()
+
+    async def close(self) -> None:
+        """Asks the external process handling calls to exit gracefully."""
+        _, writer = await asyncio.open_unix_connection(self._addr)
+        cloudpickle.dump(None, writer)
+        await writer.drain()
+        writer.write_eof()
+        self._addr.unlink()
+        self._addr.parent.rmdir()
+        await self._proc.wait()
+
+    @classmethod
+    async def create(cls) -> Self:
+        """Starts a new external call handler and connects to it."""
+        dir = tempfile.mkdtemp("tiledb-contents")
+        sock_path = pathlib.Path(dir) / "sock"
+        child = await asyncio.create_subprocess_exec(
+            sys.executable,  # Use the same Python interpreter as this process.
+            "-m",
+            "tiledbcontents.call_server",
+            "--parent-pid",
+            str(os.getpid()),
+            str(sock_path),
+        )
+        # Wait for the child process to create the socket.
+        while not sock_path.exists():
+            try:
+                await asyncio.wait_for(child.wait(), 0.01)
+            except asyncio.TimeoutError:
+                # This is fine; it means the child process is running
+                # but hasn't yet created the socket.
+                await asyncio.sleep(0.01)
+            else:
+                # If we get here, that means that the wait_for call succeeded,
+                # which means that the child process exited (i.e., crashed).
+                raise OSError("Failed to start TileDB communication process")
+        return cls(child, sock_path)

--- a/tiledbcontents/caching.py
+++ b/tiledbcontents/caching.py
@@ -7,12 +7,11 @@ import time
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, TypeVar
 
 import numpy as np
-
-from . import models
-
 import tiledb
 import tiledb.cloud
 from tiledb.cloud import client
+
+from . import models
 
 
 class Array:
@@ -178,7 +177,7 @@ class ArrayListing:
         category: str,
         namespace: Optional[str] = None,
     ) -> "ArrayListing":
-        """Fetches an ArrayListing from the cache, or constructs a new one if not present."""
+        """Fetches an ArrayListing from the cache, or constructs a new one if absent."""
         try:
             return cls._cache[category, namespace]
         except KeyError:
@@ -206,7 +205,8 @@ class ArrayListing:
                 file_type=[tiledb.cloud.rest_api.models.FileType.NOTEBOOK],
                 namespace=self.namespace,
                 async_req=True,
-                per_page=1_000_000,  # Seth this this to 1 million so we get all results back in a single request
+                # A huge number so we get everything back in one response.
+                per_page=1_000_000,
             )
             self.last_fetched = time.time()
 

--- a/tiledbcontents/call_server.py
+++ b/tiledbcontents/call_server.py
@@ -1,0 +1,100 @@
+"""Extremely simple server process which makes calls and returns results.
+
+We use this to separate out calls which use TileDB core libraries from
+the process which runs the rest of JupyterLab.
+"""
+
+import argparse
+import os
+import socketserver
+import threading
+import time
+from typing import Generic, NoReturn, TypeVar
+
+import attrs
+import cloudpickle
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+@attrs.define(frozen=True, slots=True)
+class Success(Generic[_T_co]):
+    """Wrapper for a successful return."""
+
+    value: _T_co
+
+    def result(self) -> _T_co:
+        return self.value
+
+
+@attrs.define(frozen=True, slots=True)
+class Failure:
+    """Wrapper for a failed return."""
+
+    exception: Exception
+
+    def result(self) -> NoReturn:
+        raise self.exception
+
+
+class Executor(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        result: object
+        try:
+            req = cloudpickle.load(self.rfile)
+        except Exception as e:
+            result = Failure(e)
+        else:
+            if req is None:
+                # This is the last request we should handle.
+                self.server.shutdown()
+                return
+            try:
+                result = Success(req())
+            except Exception as e:
+                result = Failure(e)
+        cloudpickle.dump(result, self.wfile)
+
+
+def parent_watchdog(ppid: int, server: socketserver.BaseServer) -> None:
+    """Watchdog function to reap this process if the parent exits."""
+    while True:
+        # When we're started, we are created as a child process of some parent,
+        # which has been passed in as the `--parent-pid` argument.
+        # If that parent process shuts down, we are adopted by some other
+        # process (usually PID 1), and our parent PID changes. Since that means
+        # no more requests, we should shut down.
+        if os.getppid() != ppid:
+            server.shutdown()
+            return
+        time.sleep(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--parent-pid",
+        type=int,
+        default=None,
+        help="""
+            PID of the parent process starting this program.
+            Used to automatically end this process if the parent exits.
+        """,
+    )
+    parser.add_argument("socket", help="Unix socket path to listen on.")
+
+    parsed = parser.parse_args()
+
+    srv = socketserver.ThreadingUnixStreamServer(parsed.socket, Executor)
+    if parsed.parent_pid:
+        threading.Thread(
+            target=parent_watchdog,
+            args=(parsed.parent_pid, srv),
+            daemon=True,
+            name="parent-watchdog",
+        ).start()
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tiledbcontents/listings.py
+++ b/tiledbcontents/listings.py
@@ -49,8 +49,9 @@ def namespace(category: str, namespace: str, *, content: bool = False) -> models
             for notebook in arrays:
                 nbmodel = models.create(path=notebook.name)
 
-                # Add notebook extension to name, so jupyterlab will open with as a notebook
-                # It seems to check the extension even though we set the "type" parameter
+                # Add notebook extension to name, so jupyterlab will open this
+                # as a notebook. It seems to check the extension even though
+                # we set the "type" parameter.
                 nbmodel["path"] = "cloud/{}/{}/{}{}".format(
                     category, namespace, nbmodel["path"], paths.NOTEBOOK_EXT
                 )
@@ -201,7 +202,8 @@ def _all_notebooks_in(category: str) -> models.Model:
                 last_modified=models.to_utc(notebook.last_accessed),
             )
             nb_model["path"] = paths.join(
-                category, nb_model["path"] + paths.NOTEBOOK_EXT)
+                category, nb_model["path"] + paths.NOTEBOOK_EXT
+            )
             model["content"].append(nb_model)
             _maybe_update_last_modified(model, notebook)
     return model

--- a/tiledbcontents/listings.py
+++ b/tiledbcontents/listings.py
@@ -2,8 +2,8 @@
 
 from typing import Any, List
 
-import tiledb.cloud
 import tornado.web
+from tiledb import cloud
 
 from . import caching
 from . import models
@@ -22,14 +22,9 @@ def namespace(category: str, namespace: str, *, content: bool = False) -> models
     try:
         listing = caching.ArrayListing.from_cache(category, namespace)
         arrays = listing.arrays()
-    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+    except cloud.TileDBCloudError as e:
         raise tornado.web.HTTPError(
             500, "Error listing notebooks in {}: {}".format(namespace, str(e))
-        )
-    except tiledb.TileDBError as e:
-        raise tornado.web.HTTPError(
-            500,
-            str(e),
         )
     except Exception as e:
         raise tornado.web.HTTPError(
@@ -83,14 +78,9 @@ def category(category: str, *, content: bool = True) -> models.Model:
     arrays = []
     try:
         arrays = caching.ArrayListing.from_cache(category).arrays()
-    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+    except cloud.TileDBCloudError as e:
         raise tornado.web.HTTPError(
             500, "Error listing notebooks in {}: {}".format(category, str(e))
-        )
-    except tiledb.TileDBError as e:
-        raise tornado.web.HTTPError(
-            500,
-            str(e),
         )
     except Exception as e:
         raise tornado.web.HTTPError(
@@ -109,7 +99,7 @@ def category(category: str, *, content: bool = True) -> models.Model:
             # listed below. This base listing is so users can create new
             # notebooks in any of the namespaces they are part of.
             try:
-                profile = tiledb.cloud.client.user_profile()
+                profile = cloud.client.user_profile()
                 namespace_model = models.create(
                     path=paths.join("cloud", category, profile.username),
                     type="directory",
@@ -130,15 +120,10 @@ def category(category: str, *, content: bool = True) -> models.Model:
 
                     namespaces[org.organization_name] = namespace_model
 
-            except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+            except cloud.TileDBCloudError as e:
                 raise tornado.web.HTTPError(
                     500,
                     "Error listing notebooks in {}: {}".format(category, str(e)),
-                )
-            except tiledb.TileDBError as e:
-                raise tornado.web.HTTPError(
-                    500,
-                    str(e),
                 )
             except Exception as e:
                 raise tornado.web.HTTPError(
@@ -173,12 +158,10 @@ def all_notebooks() -> List[models.Model]:
     """List all notebooks, across all categories."""
     try:
         return [_all_notebooks_in(cat) for cat in caching.CATEGORIES]
-    except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
+    except cloud.TileDBCloudError as e:
         raise tornado.web.HTTPError(
             500, f"Error building cloud notebook info: {e}"
         ) from e
-    except tiledb.TileDBError as e:
-        raise tornado.web.HTTPError(500, str(e)) from e
     except Exception as e:
         raise tornado.web.HTTPError(
             500, f"Error building cloud notebook info: {e}"

--- a/tiledbcontents/paths.py
+++ b/tiledbcontents/paths.py
@@ -6,7 +6,6 @@ import random
 import string
 from typing import List, Optional, Tuple
 
-
 NOTEBOOK_EXT = ".ipynb"
 _NB_NO_DOT = NOTEBOOK_EXT[1:]
 
@@ -14,7 +13,7 @@ _NB_NO_DOT = NOTEBOOK_EXT[1:]
 def maybe_trim_ipynb(path: str) -> str:
     """Removes ``.ipynb`` from the end of ``path``, if present."""
     if path.endswith(NOTEBOOK_EXT):
-        return path[:-len(NOTEBOOK_EXT)]
+        return path[: -len(NOTEBOOK_EXT)]
     return path
 
 

--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -4,17 +4,17 @@ import itertools
 import json
 import math
 import posixpath
-from typing import List, Optional
+from typing import Any, List, Optional, cast
 
 import jupyter_server.files.handlers as jsfh
-from jupyter_server.services.contents import filecheckpoints
-from jupyter_server.services.contents import filemanager
-from jupyter_server.services.contents import manager
 import nbformat
 import tiledb
 import tiledb.cloud
 import tornado.web
 import traitlets
+from jupyter_server.services.contents import filecheckpoints
+from jupyter_server.services.contents import filemanager
+from jupyter_server.services.contents import manager
 
 from . import arrays
 from . import caching
@@ -321,7 +321,8 @@ class AsyncTileDBCloudContentsManager(
         path must be a directory
         File extension can be specified.
         Use `new` to create files with a fully specified path (including filename).
-        options is a json string passed by the TileDB Prompt User Contents Jupyterlab notebook extension for additional notebook creation options
+        options is a json string passed by the TileDB Prompt User Contents
+        Jupyterlab notebook extension for additional notebook creation options
         """
         path = paths.strip(path)
         if not self.dir_exists(path):
@@ -479,7 +480,8 @@ class AsyncTileDBCloudContentsManager(
         """
         Guess the type of a file.
 
-        Taken from https://github.com/danielfrg/s3contents/blob/master/s3contents/genericmanager.py
+        Taken from
+        https://github.com/danielfrg/s3contents/blob/master/s3contents/genericmanager.py
 
         If allow_directory is False, don't consider the possibility that the
         file is a directory.
@@ -555,7 +557,7 @@ async def _file_from_array(
                 model["content"] = nb_content
                 # validate_notebook_model is an instance method that should
                 # really be a class method, since it never uses `self`.
-                manager.ContentsManager.validate_notebook_model(None, model)
+                manager.ContentsManager.validate_notebook_model(cast(Any, None), model)
         except tiledb.cloud.tiledb_cloud_error.TileDBCloudError as e:
             raise tornado.web.HTTPError(
                 500, "Error fetching file info: {}".format(str(e))


### PR DESCRIPTION
This change creates the `call_server` module and an async layer atop it to delegate all operations which run against the core TileDB library out to a separate process which will never fork and just stays around.

This review also has a preliminary commit which only includes formatting fixes.