### PR TITLE
Add code to "poison" TileDB core in the contents manager.

### DIFF
--- a/tiledbcontents/tiledbcontents.py
+++ b/tiledbcontents/tiledbcontents.py
@@ -30,6 +30,10 @@ NOTEBOOK_MIME = "application/x-ipynb+json"
 class AsyncTileDBCloudContentsManager(
     filemanager.AsyncFileContentsManager, traitlets.HasTraits
 ):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        async_tools.poison_tiledb()
+
     # This makes the checkpoints get saved on this directory
     root_dir = traitlets.Unicode("./", config=True)
 


### PR DESCRIPTION
Because some code works with TileDB core in a non-obvious manner, or a TileDB core object may be pickled across the wire and unpickled, this provides an extra layer of protection against accidentally instantiating a TileDB core object and thus breaking terminals.

---

Based on [a suggestion in the previous review](https://github.com/TileDB-Inc/TileDB-Cloud-Jupyter-Contents/pull/94#discussion_r1297303985). This handles it on the client side without affecting the generality of the call client/server architecture itself. We can use the rest of `async_tools` without poisoning TileDB, or poison TileDB without using the rest of `async_tools`.

I have also verified that this correctly breaks unpickling in addition to user instantiation with `tiledb.open` or similar functions.