### PR TITLE
Handle getting `None` arrays back from TileDB Cloud.

### DIFF
--- a/tiledbcontents/caching.py
+++ b/tiledbcontents/caching.py
@@ -239,9 +239,9 @@ _PER_PAGE = 100
 
 def _load_paginated(partial: Callable[..., Any]) -> List[object]:
     first_result = partial(page=1, per_page=_PER_PAGE)
-    everything = list(first_result.arrays)
+    everything = list(first_result.arrays or ())
     total_pages = int(first_result.pagination_metadata.total_pages)
     for subsequent in range(1, total_pages):
         next_result = partial(page=subsequent + 1, per_page=_PER_PAGE)
-        everything.extend(next_result.arrays)
+        everything.extend(next_result.arrays or ())
     return everything


### PR DESCRIPTION
When deserializing a notebook listing response from TileDB Cloud, it is possible that the generated client code handles the zero-array case by setting the `arrays` value to `None` rather than an empty iterable. This would cause a `NoneType is not iterable` exception.

I'm not *certain* if this is the case, but it's a guess.