### PR TITLE
Fix uploading of large files (in chunks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.vscode
+
 # C extensions
 *.so
 *.dylib


### PR DESCRIPTION
Jupyterlab is uploading large files in chunks. PUT `api/contents/{{file_name}}`

```json
{
    "type": "file",
    "format": "base64",
    "name": "sample.pdf",
    "chunk": 5,
    "content": "Tnb3YlnOD...",
    "path": "sample.pdf"
}
```

Instead of using the original `save` method, we can use [AsyncFileManager's save method](https://github.com/jupyter-server/jupyter_server/blob/74655ce66f36ed85a83591e6658e70ba91232580/jupyter_server/services/contents/largefilemanager.py#L88).

### Ways to test

Upload a file larger than 40mb in a non `/cloud` folder.
<img width="85" alt="image" src="https://github.com/user-attachments/assets/434fde24-4c79-4946-9b80-510f5a317e37">
*Upload button*


Story details: https://app.shortcut.com/tiledb-inc/story/55469